### PR TITLE
Border support for QtSpecem

### DIFF
--- a/QtSpecem.h
+++ b/QtSpecem.h
@@ -16,6 +16,7 @@ public:
 	void paintEvent(QPaintEvent *) override;
 	void KeyPress(QMainWindow *parent = 0);
 protected:
+    void drawBorder();
     void keyPressEvent(QKeyEvent *) override;
     void keyReleaseEvent(QKeyEvent *) override;
     void dragEnterEvent(QDragEnterEvent *event) override;

--- a/emul/ports.c
+++ b/emul/ports.c
@@ -44,7 +44,9 @@ void writeport(USHORT port, UCHAR value)
         //              4:  1 activates EAR / Internal Speaker
 
         borderColor = value & 7;
-        
+
+        border_updated(borderColor, clock_ticks);
+
         out_ula = value;
        
                 /*        if (out_ula & 0x10)


### PR DESCRIPTION
This patch adds support for border, indexed to the Z80 T-states (since last interrupt).